### PR TITLE
feat: enable Fedora 41 builds (#27)

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -37,6 +37,7 @@ jobs:
         fedora_version:
           - 39
           - 40
+          - 41
         exclude:
           - fedora_version: 39
             kernel_flavor: asus
@@ -46,6 +47,16 @@ jobs:
             kernel_flavor: fsync
           - fedora_version: 39
             kernel_flavor: fsync-ba
+          - fedora_version: 41
+            kernel_flavor: fsync
+          - fedora_version: 41
+            kernel_flavor: fsync-ba
+          - fedora_version: 41
+            kernel_flavor: coreos-stable
+          - fedora_version: 41
+            kernel_flavor: coreos-testing
+          - fedora_version: 41
+            kernel_flavor: surface
 
     steps:
       - name: Checkout Push to Registry action
@@ -89,6 +100,7 @@ jobs:
               echo "Querying koji for ${coreos_version} kernel: $kernel_version"
               echo "$URL"
               HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
+              linux=""
               if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
                 echo "Koji failed to find $coreos_version kernel: $kernel_version"
                 case "$kernel_rel_part" in

--- a/fetch.sh
+++ b/fetch.sh
@@ -5,7 +5,7 @@ set -eoux pipefail
 kernel_version="${KERNEL_VERSION}"
 kernel_flavor="${KERNEL_FLAVOR}"
 
-#CoreOS pool repo
+# CoreOS pool repo
 # curl -LsSf -o /etc/yum.repos.d/fedora-coreos-pool.repo \
 #     https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo
 
@@ -58,20 +58,19 @@ elif [[ "${kernel_flavor}" == "surface" ]]; then
         libwacom-surface \
         libwacom-surface-data
 
-
 else
     KERNEL_MAJOR_MINOR_PATCH=$(echo "$kernel_version" | cut -d '-' -f 1)
     KERNEL_RELEASE="$(echo "$kernel_version" | cut -d - -f 2 | cut -d . -f 1).$(echo "$kernel_version" | cut -d - -f 2 | cut -d . -f 2)"
     ARCH=$(uname -m)
-    dnf download -y \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-core-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-extra-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-matched-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-uki-virt-"$kernel_version".rpm
-
+    
+    # Using curl instead of dnf download for https links
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-core-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-extra-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-matched-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-uki-virt-"$kernel_version".rpm
 fi
 
 if [[ "${kernel_flavor}" =~ fsync|fsync-ba ]]; then
@@ -93,6 +92,7 @@ openssl x509 -in /tmp/certs/public_key.der -out /tmp/certs/public_key.crt
 install -Dm644 /tmp/certs/public_key.crt "$PUBLIC_KEY_PATH"
 install -Dm644 /tmp/certs/private_key.priv "$PRIVATE_KEY_PATH"
 
+ls -la /
 if [[ "${kernel_flavor}" =~ asus|fsync|fsync-ba ]]; then
     dnf install -y \
         /kernel-"$kernel_version".rpm \
@@ -154,9 +154,11 @@ if [[ ${DUAL_SIGN:-} == "true" ]]; then
     rm -f "$SECOND_PRIVATE_KEY_PATH" "$SECOND_PUBLIC_KEY_PATH"
 fi
 
+ln -s / /tmp/buildroot
+
 # Rebuild RPMs and Verify
 if [[ "${kernel_flavor}" =~ surface ]]; then
-    rpmrebuild --batch kernel-surface-core-"${kernel_version}"
+    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch kernel-surface-core-"${kernel_version}"
     rm -f /usr/lib/modules/"${kernel_version}"/vmlinuz
     dnf reinstall -y \
         /kernel-surface-"$kernel_version".rpm \
@@ -165,7 +167,7 @@ if [[ "${kernel_flavor}" =~ surface ]]; then
         /kernel-surface-modules-extra-"$kernel_version".rpm \
         /root/rpmbuild/RPMS/"$(uname -m)"/kernel-*.rpm
 else
-    rpmrebuild --batch kernel-core-"${kernel_version}"
+    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch kernel-core-"${kernel_version}"
     rm -f /usr/lib/modules/"${kernel_version}"/vmlinuz
     dnf reinstall -y \
         /kernel-"$kernel_version".rpm \


### PR DESCRIPTION
* feat: enable Fedora 41 builds

* chore: improve logging of kernel version extraction

* fix: unset variable and list root directory contents

* fix: use curl rather than dnf download

* fix: add noprep flag

* fix: rpmrebuild use symlink and specified buildroot

* fix: disable not yet built F41 kernels

---------

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
